### PR TITLE
LOGR: Provide UT stub and improve encapsulation

### DIFF
--- a/CTRL/test/UT_Controller.cpp
+++ b/CTRL/test/UT_Controller.cpp
@@ -1,6 +1,7 @@
 #include "CTRL/Controller.hpp"
 
 #include "DRVR/IDriver.hpp"
+#include "LOGR/ILogger.hpp"
 
 #include "gtest/gtest.h"
 #include "gmock/gmock.h"
@@ -24,6 +25,7 @@ public:
 
 TEST(TestController, ExecuteMoveTogglesLogging)
 {
+    auto logr = LOGR::ILoggerStub::create("CTRL_UT");
     auto driverMock = std::make_shared<NiceMock<DriverMock>>();
 
     Controller controller(driverMock);

--- a/LOGR/CMakeLists.txt
+++ b/LOGR/CMakeLists.txt
@@ -15,14 +15,15 @@ add_library(
     ${EXT_INC_PATH}/${PROJECT_NAME}/Exception.hpp
     ${EXT_INC_PATH}/${PROJECT_NAME}/internal.hpp
     ${EXT_INC_PATH}/${PROJECT_NAME}/ILogger.hpp
-    ${EXT_INC_PATH}/${PROJECT_NAME}/Logger.hpp
     ${EXT_INC_PATH}/${PROJECT_NAME}/Trace.hpp
     ${EXT_INC_PATH}/${PROJECT_NAME}/Warning.hpp
+
+    ${INT_INC_PATH}/LoggerImpl.hpp
 
     ${SRC_PATH}/Exception.cpp
     ${SRC_PATH}/internal.cpp
     ${SRC_PATH}/ILogger.cpp
-    ${SRC_PATH}/Logger.cpp
+    ${SRC_PATH}/LoggerImpl.cpp
 )
 
 target_include_directories(${PROJECT_NAME} PUBLIC ${EXT_INC_PATH})

--- a/LOGR/CMakeLists.txt
+++ b/LOGR/CMakeLists.txt
@@ -14,12 +14,14 @@ add_library(
     ${PROJECT_NAME} SHARED
     ${EXT_INC_PATH}/${PROJECT_NAME}/Exception.hpp
     ${EXT_INC_PATH}/${PROJECT_NAME}/internal.hpp
+    ${EXT_INC_PATH}/${PROJECT_NAME}/ILogger.hpp
     ${EXT_INC_PATH}/${PROJECT_NAME}/Logger.hpp
     ${EXT_INC_PATH}/${PROJECT_NAME}/Trace.hpp
     ${EXT_INC_PATH}/${PROJECT_NAME}/Warning.hpp
 
     ${SRC_PATH}/Exception.cpp
     ${SRC_PATH}/internal.cpp
+    ${SRC_PATH}/ILogger.cpp
     ${SRC_PATH}/Logger.cpp
 )
 

--- a/LOGR/inc/LoggerImpl.hpp
+++ b/LOGR/inc/LoggerImpl.hpp
@@ -10,7 +10,7 @@
 #include <thread>
 #include <queue>
 
-#include "ILogger.hpp"
+#include "LOGR/ILogger.hpp"
 
 
 namespace LOGR
@@ -34,11 +34,11 @@ class LoggerNotSet : public std::runtime_error
 ///
 /// All logging is asynchronous and safe to use from multiple threads.
 ///
-class Logger : public ILogger
+class LoggerImpl : public ILogger
 {
 public:
-    Logger(const std::string& taskName);
-    ~Logger();
+    LoggerImpl(const std::string& taskName);
+    ~LoggerImpl();
 
     virtual void queueLogLine(const std::string& line) override;
 
@@ -55,7 +55,7 @@ private:
     std::thread m_ioThread;
     std::atomic<bool> m_keepLogging;
 
-    static Logger *m_logger;
+    static LoggerImpl *m_logger;
 };
 
 }

--- a/LOGR/inc/LoggerImpl.hpp
+++ b/LOGR/inc/LoggerImpl.hpp
@@ -16,23 +16,8 @@
 namespace LOGR
 {
 
-class LoggerAlreadySet : public std::runtime_error
-{
-    using std::runtime_error::runtime_error;
-};
-
-class LoggerNotSet : public std::runtime_error
-{
-    using std::runtime_error::runtime_error;
-};
-
 ///
-/// \brief Manage a log-file per 'task' / process
-///
-/// You are expected to create a single `Logger` object in your `main()`
-/// function, which enables the use of the other logging classes.
-///
-/// All logging is asynchronous and safe to use from multiple threads.
+/// \brief The production ILogger implementation.
 ///
 class LoggerImpl : public ILogger
 {

--- a/LOGR/include/LOGR/ILogger.hpp
+++ b/LOGR/include/LOGR/ILogger.hpp
@@ -30,6 +30,7 @@ class ILogger
 {
 public:
     static std::shared_ptr<ILogger> create(const std::string& taskName);
+    virtual ~ILogger() = default;
 
 protected:
     template<typename... Args>
@@ -52,7 +53,7 @@ protected:
 ///
 /// All logging calls are thread-safe, but blocking unlike in production.
 ///
-class ILoggerStub : ILogger
+class ILoggerStub : public ILogger
 {
 public:
     static std::shared_ptr<ILogger> create(const std::string& taskName);

--- a/LOGR/include/LOGR/ILogger.hpp
+++ b/LOGR/include/LOGR/ILogger.hpp
@@ -7,8 +7,18 @@
 namespace LOGR
 {
 
+class LoggerNotSet : public std::runtime_error
+{
+    using std::runtime_error::runtime_error;
+};
+
+class LoggerAlreadySet : public std::runtime_error
+{
+    using std::runtime_error::runtime_error;
+};
+
 ///
-/// \brief Manage a log-file per 'task' / process
+/// \brief Manage a log-file per 'task' / process.
 ///
 /// You are expected to `create()` a single `Logger` object in your `main()`
 /// function, which enables the use of the other logging classes for this
@@ -35,10 +45,10 @@ protected:
 };
 
 ///
-/// \brief Stub for unit-tests that can log to stderr
+/// \brief Stub for unit-tests, logs to stderr.
 ///
 /// Use this `create()` instead of the production one to enable your system
-/// under test to use the other logging classes
+/// under test to use the other logging classes.
 ///
 /// All logging calls are thread-safe, but blocking unlike in production.
 ///

--- a/LOGR/include/LOGR/ILogger.hpp
+++ b/LOGR/include/LOGR/ILogger.hpp
@@ -1,0 +1,53 @@
+#ifndef LOGR_INCLUDE_LOGR_ILOGGER
+#define LOGR_INCLUDE_LOGR_ILOGGER
+
+#include <memory>
+#include <string>
+
+namespace LOGR
+{
+
+///
+/// \brief Manage a log-file per 'task' / process
+///
+/// You are expected to `create()` a single `Logger` object in your `main()`
+/// function, which enables the use of the other logging classes for this
+/// object's lifetime. The log-file is closed upon destruction.
+///
+/// All logging is asynchronous and safe to use from multiple threads.
+///
+class ILogger
+{
+public:
+    static std::shared_ptr<ILogger> create(const std::string& taskName);
+
+protected:
+    template<typename... Args>
+    friend class Trace;
+    template <typename... Ts>
+    friend class Warning;
+    friend class Exception;
+
+    static std::shared_ptr<ILogger> instance();
+    virtual void queueLogLine(const std::string& line) = 0;
+
+    static std::weak_ptr<ILogger> m_instance;
+};
+
+///
+/// \brief Stub for unit-tests that can log to stderr
+///
+/// Use this `create()` instead of the production one to enable your system
+/// under test to use the other logging classes
+///
+/// All logging calls are thread-safe, but blocking unlike in production.
+///
+class ILoggerStub : ILogger
+{
+public:
+    static std::shared_ptr<ILogger> create(const std::string& taskName);
+};
+
+}
+
+#endif // LOGR_INCLUDE_LOGR_ILOGGER

--- a/LOGR/include/LOGR/Logger.hpp
+++ b/LOGR/include/LOGR/Logger.hpp
@@ -10,6 +10,8 @@
 #include <thread>
 #include <queue>
 
+#include "ILogger.hpp"
+
 
 namespace LOGR
 {
@@ -32,13 +34,13 @@ class LoggerNotSet : public std::runtime_error
 ///
 /// All logging is asynchronous and safe to use from multiple threads.
 ///
-class Logger
+class Logger : public ILogger
 {
 public:
     Logger(const std::string& taskName);
     ~Logger();
 
-    static void queueLogLine(const std::string& line);
+    virtual void queueLogLine(const std::string& line) override;
 
 private:
     void logSome(size_t nrLinesToLog);

--- a/LOGR/include/LOGR/Trace.hpp
+++ b/LOGR/include/LOGR/Trace.hpp
@@ -31,7 +31,7 @@ public:
         line << "v";
         ((line << " " << std::forward<Ts>(args)), ...);
         line << "\n";
-        Logger::queueLogLine(line.str());
+        Logger::instance()->queueLogLine(line.str());
     }
 
     Trace(Ts&&... args,
@@ -41,14 +41,14 @@ public:
     {
         auto line = internal::startLine(internal::Level::TRACE, m_loc);
         line << "v\n";
-        Logger::queueLogLine(line.str());
+        Logger::instance()->queueLogLine(line.str());
     }
 
     ~Trace()
     {
         auto line = internal::startLine(internal::Level::TRACE, m_loc);
         line << "^\n";
-        Logger::queueLogLine(line.str());
+        Logger::instance()->queueLogLine(line.str());
     }
 
     template <typename... T1s>
@@ -58,7 +58,7 @@ public:
         line << "|";
         ((line << " " << std::forward<T1s>(args)), ...);
         line << "\n";
-        Logger::queueLogLine(line.str());
+        Logger::instance()->queueLogLine(line.str());
     }
 
 private:

--- a/LOGR/include/LOGR/Trace.hpp
+++ b/LOGR/include/LOGR/Trace.hpp
@@ -11,7 +11,7 @@ namespace LOGR
 {
 
 ///
-/// \brief Log useful info and function execution flow
+/// \brief Log function execution flow and other useful info.
 ///
 /// A `Trace` object automatically logs its creation and destruction,
 /// usually used to mark the start and end of a function.

--- a/LOGR/include/LOGR/Trace.hpp
+++ b/LOGR/include/LOGR/Trace.hpp
@@ -4,7 +4,7 @@
 #include <source_location>
 
 #include "internal.hpp"
-#include "Logger.hpp"
+#include "ILogger.hpp"
 
 
 namespace LOGR
@@ -31,7 +31,7 @@ public:
         line << "v";
         ((line << " " << std::forward<Ts>(args)), ...);
         line << "\n";
-        Logger::instance()->queueLogLine(line.str());
+        ILogger::instance()->queueLogLine(line.str());
     }
 
     Trace(Ts&&... args,
@@ -41,14 +41,14 @@ public:
     {
         auto line = internal::startLine(internal::Level::TRACE, m_loc);
         line << "v\n";
-        Logger::instance()->queueLogLine(line.str());
+        ILogger::instance()->queueLogLine(line.str());
     }
 
     ~Trace()
     {
         auto line = internal::startLine(internal::Level::TRACE, m_loc);
         line << "^\n";
-        Logger::instance()->queueLogLine(line.str());
+        ILogger::instance()->queueLogLine(line.str());
     }
 
     template <typename... T1s>
@@ -58,7 +58,7 @@ public:
         line << "|";
         ((line << " " << std::forward<T1s>(args)), ...);
         line << "\n";
-        Logger::instance()->queueLogLine(line.str());
+        ILogger::instance()->queueLogLine(line.str());
     }
 
 private:

--- a/LOGR/include/LOGR/Warning.hpp
+++ b/LOGR/include/LOGR/Warning.hpp
@@ -11,7 +11,7 @@ namespace LOGR
 {
 
 ///
-/// \brief Log a potentially problematic situation
+/// \brief Log a potentially problematic situation.
 ///
 /// A `Warning` object immediately logs the message (marked as a warning)
 /// and is useless afterwards - it is meant to be created as a temporary.

--- a/LOGR/include/LOGR/Warning.hpp
+++ b/LOGR/include/LOGR/Warning.hpp
@@ -30,7 +30,7 @@ public:
         line << "!";
         ((line << " " << std::forward<Ts>(args)), ...);
         line << "\n";
-        Logger::queueLogLine(line.str());
+        Logger::instance()->queueLogLine(line.str());
     }
 };
 

--- a/LOGR/include/LOGR/Warning.hpp
+++ b/LOGR/include/LOGR/Warning.hpp
@@ -4,7 +4,7 @@
 #include <source_location>
 
 #include "LOGR/internal.hpp"
-#include "LOGR/Logger.hpp"
+#include "ILogger.hpp"
 
 
 namespace LOGR
@@ -30,7 +30,7 @@ public:
         line << "!";
         ((line << " " << std::forward<Ts>(args)), ...);
         line << "\n";
-        Logger::instance()->queueLogLine(line.str());
+        ILogger::instance()->queueLogLine(line.str());
     }
 };
 

--- a/LOGR/src/Exception.cpp
+++ b/LOGR/src/Exception.cpp
@@ -6,7 +6,7 @@
 #include <string>
 
 #include "LOGR/internal.hpp"
-#include "LOGR/Logger.hpp"
+#include "LoggerImpl.hpp"
 
 
 std::atomic<unsigned long long> LOGR::Exception::freeId = 1;
@@ -17,7 +17,7 @@ LOGR::Exception::Exception(const std::string& message,
 {
     auto line = internal::startLine(internal::Level::EXCEPTION, loc);
     line << "> [" << id << "] " << this->what() << "\n";
-    Logger::instance()->queueLogLine(line.str());
+    LoggerImpl::instance()->queueLogLine(line.str());
 }
 
 void LOGR::Exception::handle(const std::string& message,
@@ -25,5 +25,5 @@ void LOGR::Exception::handle(const std::string& message,
 {
     auto line = internal::startLine(internal::Level::EXCEPTION, loc);
     line << "< [" << id << "] " << message << "\n";
-    Logger::instance()->queueLogLine(line.str());
+    LoggerImpl::instance()->queueLogLine(line.str());
 }

--- a/LOGR/src/Exception.cpp
+++ b/LOGR/src/Exception.cpp
@@ -17,7 +17,7 @@ LOGR::Exception::Exception(const std::string& message,
 {
     auto line = internal::startLine(internal::Level::EXCEPTION, loc);
     line << "> [" << id << "] " << this->what() << "\n";
-    Logger::queueLogLine(line.str());
+    Logger::instance()->queueLogLine(line.str());
 }
 
 void LOGR::Exception::handle(const std::string& message,
@@ -25,5 +25,5 @@ void LOGR::Exception::handle(const std::string& message,
 {
     auto line = internal::startLine(internal::Level::EXCEPTION, loc);
     line << "< [" << id << "] " << message << "\n";
-    Logger::queueLogLine(line.str());
+    Logger::instance()->queueLogLine(line.str());
 }

--- a/LOGR/src/ILogger.cpp
+++ b/LOGR/src/ILogger.cpp
@@ -15,8 +15,8 @@ std::shared_ptr<ILogger> ILogger::create(const std::string& taskName)
 {
     if (m_instance.use_count() > 0)
     {
-        throw LoggerAlreadySet("You must create exactly one Logger object "
-                               "per executable (or at least at one time).");
+        throw LoggerAlreadySet(
+            "Only one Logger per executable can exist at a time.");
     }
 
     auto logger = std::make_shared<LoggerImpl>(taskName);
@@ -29,8 +29,8 @@ std::shared_ptr<ILogger> ILogger::instance()
     auto instance = m_instance.lock();
     if (not instance)
     {
-        throw LoggerNotSet("You must create exactly one Logger object "
-                           "per executable (or at least at one time).");
+        throw LoggerNotSet(
+            "A Logger object must be created before logging.");
     }
     return instance;
 }

--- a/LOGR/src/ILogger.cpp
+++ b/LOGR/src/ILogger.cpp
@@ -1,0 +1,65 @@
+#include "LOGR/ILogger.hpp"
+
+#include <iostream>
+
+#include "LOGR/Logger.hpp"
+#include "LOGR/internal.hpp"
+
+
+namespace LOGR
+{
+
+std::weak_ptr<ILogger> ILogger::m_instance = {};
+
+class LoggerStub : public ILogger
+{
+public:
+    LoggerStub(const std::string& taskName)
+        : m_taskName(taskName)
+    { }
+
+protected:
+    virtual void queueLogLine(const std::string& line) override
+    {
+        std::unique_lock logLock(m_logMutex);
+        std::cerr << "[" << m_taskName << "]" << internal::SEPARATOR << line;
+    }
+
+private:
+    std::mutex m_logMutex;
+    const std::string m_taskName;
+};
+
+std::shared_ptr<ILogger> ILogger::create(const std::string& taskName)
+{
+    if (m_instance.use_count() > 0)
+    {
+        throw LoggerAlreadySet("You must create exactly one Logger object "
+                               "per executable (or at least at one time).");
+    }
+
+    auto logger = std::make_shared<Logger>(taskName);
+    m_instance = logger;
+    return logger;
+}
+
+std::shared_ptr<ILogger> ILogger::instance()
+{
+    auto instance = m_instance.lock();
+    if (not instance)
+    {
+        throw LoggerNotSet("You must create exactly one Logger object "
+                           "per executable (or at least at one time).");
+    }
+    return instance;
+}
+
+std::shared_ptr<ILogger> ILoggerStub::create(const std::string& taskName)
+{
+    auto logger = std::make_shared<LoggerStub>(taskName);
+    m_instance = logger;
+    return logger;
+}
+
+
+}

--- a/LOGR/src/ILogger.cpp
+++ b/LOGR/src/ILogger.cpp
@@ -2,7 +2,7 @@
 
 #include <iostream>
 
-#include "LOGR/Logger.hpp"
+#include "LoggerImpl.hpp"
 #include "LOGR/internal.hpp"
 
 
@@ -38,7 +38,7 @@ std::shared_ptr<ILogger> ILogger::create(const std::string& taskName)
                                "per executable (or at least at one time).");
     }
 
-    auto logger = std::make_shared<Logger>(taskName);
+    auto logger = std::make_shared<LoggerImpl>(taskName);
     m_instance = logger;
     return logger;
 }

--- a/LOGR/src/ILogger.cpp
+++ b/LOGR/src/ILogger.cpp
@@ -11,25 +11,6 @@ namespace LOGR
 
 std::weak_ptr<ILogger> ILogger::m_instance = {};
 
-class LoggerStub : public ILogger
-{
-public:
-    LoggerStub(const std::string& taskName)
-        : m_taskName(taskName)
-    { }
-
-protected:
-    virtual void queueLogLine(const std::string& line) override
-    {
-        std::unique_lock logLock(m_logMutex);
-        std::cerr << "[" << m_taskName << "]" << internal::SEPARATOR << line;
-    }
-
-private:
-    std::mutex m_logMutex;
-    const std::string m_taskName;
-};
-
 std::shared_ptr<ILogger> ILogger::create(const std::string& taskName)
 {
     if (m_instance.use_count() > 0)
@@ -54,12 +35,31 @@ std::shared_ptr<ILogger> ILogger::instance()
     return instance;
 }
 
+
+class LoggerStub : public ILoggerStub
+{
+public:
+    LoggerStub(const std::string& taskName)
+        : m_taskName(taskName)
+    { }
+
+protected:
+    virtual void queueLogLine(const std::string& line) override
+    {
+        std::unique_lock logLock(m_logMutex);
+        std::cerr << "[" << m_taskName << "]" << internal::SEPARATOR << line;
+    }
+
+private:
+    std::mutex m_logMutex;
+    const std::string m_taskName;
+};
+
 std::shared_ptr<ILogger> ILoggerStub::create(const std::string& taskName)
 {
     auto logger = std::make_shared<LoggerStub>(taskName);
-    m_instance = logger;
-    return logger;
+    m_instance = std::dynamic_pointer_cast<ILogger>(logger);
+    return std::dynamic_pointer_cast<ILogger>(logger);
 }
-
 
 }

--- a/LOGR/src/LoggerImpl.cpp
+++ b/LOGR/src/LoggerImpl.cpp
@@ -1,4 +1,4 @@
-#include "LOGR/Logger.hpp"
+#include "LoggerImpl.hpp"
 
 #include <chrono>
 #include <sstream>
@@ -7,7 +7,7 @@
 namespace LOGR
 {
 
-Logger * Logger::m_logger = nullptr;
+LoggerImpl * LoggerImpl::m_logger = nullptr;
 
 static inline std::string generateLogfileName(const std::string& taskName)
 {
@@ -20,7 +20,7 @@ static inline std::string generateLogfileName(const std::string& taskName)
     return stream.str();
 }
 
-void Logger::queueLogLine(const std::string& line)
+void LoggerImpl::queueLogLine(const std::string& line)
 {
     if (not m_logger)
     {
@@ -33,7 +33,7 @@ void Logger::queueLogLine(const std::string& line)
     m_logger->m_toLog.emplace(line);
 }
 
-void Logger::logSome(size_t nrLinesToLog)
+void LoggerImpl::logSome(size_t nrLinesToLog)
 {
     std::vector<std::string> toLog;
     {
@@ -53,7 +53,7 @@ void Logger::logSome(size_t nrLinesToLog)
     }
 }
 
-Logger::Logger(const std::string& taskName)
+LoggerImpl::LoggerImpl(const std::string& taskName)
     : m_taskName(taskName),
       m_logFile(generateLogfileName(taskName)),
       m_keepLogging(true)
@@ -76,7 +76,7 @@ Logger::Logger(const std::string& taskName)
     m_ioThread = std::thread(ioJob);
 }
 
-Logger::~Logger()
+LoggerImpl::~LoggerImpl()
 {
     m_keepLogging = false;
     m_ioThread.join();

--- a/MAIN/src/main.cpp
+++ b/MAIN/src/main.cpp
@@ -1,7 +1,6 @@
 #include "UI/UserInterface.hpp"
 #include "DRVR/Driver.hpp"
 #include "CTRL/Controller.hpp"
-#include "LOGR/Logger.hpp"
 #include "LOGR/ILogger.hpp"
 #include "LOGR/Trace.hpp"
 

--- a/MAIN/src/main.cpp
+++ b/MAIN/src/main.cpp
@@ -2,6 +2,7 @@
 #include "DRVR/Driver.hpp"
 #include "CTRL/Controller.hpp"
 #include "LOGR/Logger.hpp"
+#include "LOGR/ILogger.hpp"
 #include "LOGR/Trace.hpp"
 
 #include <chrono>
@@ -11,7 +12,7 @@
 int main()
 {
     using namespace std::literals;
-    LOGR::Logger logger("MAIN");
+    auto logger = LOGR::ILogger::create("MAIN");
 
     LOGR::Trace trace;
 


### PR DESCRIPTION
Fixes #12 by adding a `std::cerr`-logging stub implementation for use in unit-tests.

Encapsulation is improved by extracting the Logger details (private members) into `LoggerImpl`.