### PR TITLE
Remove redundant 'cmake_minimum_required' in subprojects

### DIFF
--- a/CTRL/CMakeLists.txt
+++ b/CTRL/CMakeLists.txt
@@ -1,5 +1,3 @@
-cmake_minimum_required(VERSION 3.14)
-
 project(CTRL)
 
 set(SRC_PATH ${CMAKE_CURRENT_SOURCE_DIR}/src)

--- a/CTRL/test/CMakeLists.txt
+++ b/CTRL/test/CMakeLists.txt
@@ -1,5 +1,3 @@
-cmake_minimum_required(VERSION 3.14)
-
 project(CTRL_test)
 
 add_executable(

--- a/DOMN/CMakeLists.txt
+++ b/DOMN/CMakeLists.txt
@@ -1,5 +1,3 @@
-cmake_minimum_required(VERSION 3.14)
-
 project(DOMN)
 
 set(SRC_PATH ${CMAKE_CURRENT_SOURCE_DIR}/src)

--- a/DOMN/test/CMakeLists.txt
+++ b/DOMN/test/CMakeLists.txt
@@ -1,5 +1,3 @@
-cmake_minimum_required(VERSION 3.14)
-
 project(TODO_test)
 
 # add_executable(

--- a/DRVR/CMakeLists.txt
+++ b/DRVR/CMakeLists.txt
@@ -1,5 +1,3 @@
-cmake_minimum_required(VERSION 3.14)
-
 project(DRVR)
 
 set(SRC_PATH ${CMAKE_CURRENT_SOURCE_DIR}/src)

--- a/DRVR/test/CMakeLists.txt
+++ b/DRVR/test/CMakeLists.txt
@@ -1,5 +1,3 @@
-cmake_minimum_required(VERSION 3.14)
-
 project(TODO_test)
 
 # add_executable(

--- a/LOGR/CMakeLists.txt
+++ b/LOGR/CMakeLists.txt
@@ -1,5 +1,3 @@
-cmake_minimum_required(VERSION 3.14)
-
 project(LOGR)
 
 set(SRC_PATH ${CMAKE_CURRENT_SOURCE_DIR}/src)

--- a/LOGR/test/CMakeLists.txt
+++ b/LOGR/test/CMakeLists.txt
@@ -1,5 +1,3 @@
-cmake_minimum_required(VERSION 3.14)
-
 project(LOGR_test)
 
 add_executable(

--- a/MAIN/CMakeLists.txt
+++ b/MAIN/CMakeLists.txt
@@ -1,5 +1,3 @@
-cmake_minimum_required(VERSION 3.14)
-
 project(MAIN)
 
 set(SRC_PATH ${CMAKE_CURRENT_SOURCE_DIR}/src)

--- a/MAIN/test/CMakeLists.txt
+++ b/MAIN/test/CMakeLists.txt
@@ -1,5 +1,3 @@
-cmake_minimum_required(VERSION 3.14)
-
 project(TODO_test)
 
 # add_executable(

--- a/UI/CMakeLists.txt
+++ b/UI/CMakeLists.txt
@@ -1,5 +1,3 @@
-cmake_minimum_required(VERSION 3.14)
-
 project(UI)
 
 set(SRC_PATH ${CMAKE_CURRENT_SOURCE_DIR}/src)

--- a/UI/test/CMakeLists.txt
+++ b/UI/test/CMakeLists.txt
@@ -1,5 +1,3 @@
-cmake_minimum_required(VERSION 3.14)
-
 project(TODO_test)
 
 # add_executable(


### PR DESCRIPTION
This is just unnecessary duplication at this point.

If any components get split off as submodules, they'll need it back; but for the moment we don't have the infrastructure for that anyway _(e.g. external dependencies are managed centrally)_.
So, not worth the maintenance cost.