### PR TITLE
Block PRs with merge commits

### DIFF
--- a/.github/workflows/check-pull-requests.yml
+++ b/.github/workflows/check-pull-requests.yml
@@ -1,0 +1,16 @@
+name: Check Pull Requests
+
+on:
+  pull_request:
+    branches: [ "main" ]
+
+jobs:
+  check-pr:
+    name: Check PRs
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: No Merge Commits
+      uses: Morishiri/block-merge-commits-action@v1.0.1
+      with:
+        repo-token: ${{ secrets.READONLY_API_TOKEN }}


### PR DESCRIPTION
Adds a GitHub workflow/check that fails if the Pull Request branch (targeting `main`) contains any **merge commits**.

The idea is to enforce a so-called **semi-linear history**, where `main` contains individual, sequential 'bubbles' of commits, each coming from a particular PR.

This requires _rebasing_ feature branches to update them with new additions in `main`:

```mermaid
gitGraph
commit id: "Init"
branch feature-a
commit id: "Implement A"
commit id: "Add docs for A"
checkout main
merge feature-a
branch feature-b
commit id: "Implement B"
commit id: "Add tests for B"
checkout main
merge feature-b
```

... as opposed to _merging_ `main`:

```mermaid
gitGraph
commit id: "Init"
branch feature-b
branch feature-a
commit id: "Implement A"
checkout feature-b
commit id: "Implement B"
checkout feature-a
commit id: "Add docs for A"
checkout main
merge feature-a
checkout feature-b
merge main id: "Merge main into B" tag: "bad"
commit id: "Add tests for B"
checkout main
merge feature-b
```

... where the worst effect is that merge commits _also end up in `main`_.