### PR TITLE
Add dependencies for COMM

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,8 @@ cmake_minimum_required(VERSION 3.16)
 
 project(linebot)
 
+find_package(Python COMPONENTS Interpreter REQUIRED)
+
 set(cmake_helpers_DIR cmake_helpers)
 find_package(cmake_helpers REQUIRED)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.14)
+cmake_minimum_required(VERSION 3.16)
 
 project(linebot)
 
@@ -20,7 +20,7 @@ find_package(Threads REQUIRED)
 include(FetchContent)
 FetchContent_Declare(
   googletest
-  URL https://github.com/google/googletest/archive/03597a01ee50ed33e9dfd640b249b4be3799d395.zip
+  URL https://github.com/google/googletest/archive/0bdccf4aa2f5c67af967193caf31d42d5c49bde2.zip
 )
 # For Windows: Prevent overriding the parent project's compiler/linker settings
 set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,6 +18,7 @@ set(THREADS_PREFER_PTHREAD_FLAG ON)
 find_package(Threads REQUIRED)
 
 include(FetchContent)
+
 FetchContent_Declare(
   googletest
   URL https://github.com/google/googletest/archive/0bdccf4aa2f5c67af967193caf31d42d5c49bde2.zip
@@ -27,6 +28,14 @@ set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
 FetchContent_MakeAvailable(googletest)
 
 enable_testing()
+
+FetchContent_Declare(
+  zpp_bits
+  URL https://github.com/eyalz800/zpp_bits/archive/refs/tags/v4.4.25.zip
+)
+FetchContent_MakeAvailable(zpp_bits)
+
+include_directories(${zpp_bits_SOURCE_DIR})
 
 find_package(Doxygen QUIET)
 


### PR DESCRIPTION
- Bump up the Google Test version,
- Add serialization library [`zpp_bits`](https://github.com/eyalz800/zpp_bits) (MIT-licensed),
- Add Python requirement (and availability) in CMake.

These are prerequisites for the initial, MVP design of the `COMM` _interface generator._
(However, I am considering a move from binary serialization to JSON for easier interoperability with Python.)