### PR TITLE
Add cppcheck static analysis

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,5 +1,5 @@
 {
-  "image": "mcr.microsoft.com/devcontainers/cpp:ubuntu-22.04",
+  "image": "mcr.microsoft.com/devcontainers/cpp:ubuntu-24.04",
   "customizations": {
     "vscode": {
       "extensions": [

--- a/.devcontainer/init.sh
+++ b/.devcontainer/init.sh
@@ -5,8 +5,12 @@ git submodule update --recursive --init
 # Update/upgrade
 sudo DEBIAN_FRONTEND=noninteractive apt -y update && sudo DEBIAN_FRONTEND=noninteractive apt -y upgrade
 
+# Install cppcheck
+sudo DEBIAN_FRONTEND=noninteractive apt -y install cppcheck
+
 # Install llvm.sh dependencies
 sudo DEBIAN_FRONTEND=noninteractive apt -y install lsb-release wget software-properties-common gnupg
+# .. and clang 21
 sudo .devcontainer/llvm.sh 21
 
 # Update/upgrade again (llvm install script adds new apt repo)

--- a/.github/workflows/cmake-single-platform.yml
+++ b/.github/workflows/cmake-single-platform.yml
@@ -24,6 +24,10 @@ jobs:
       with:
         submodules: recursive
 
+    - name: Install Dependencies
+      run: |
+        sudo apt-get install cppcheck
+
     - name: Configure CMake
       # Configure CMake in a 'build' subdirectory. `CMAKE_BUILD_TYPE` is only required if you are using a single-configuration generator such as make.
       # See https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html?highlight=cmake_build_type

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,6 +41,15 @@ include_directories(${zpp_bits_SOURCE_DIR})
 
 find_package(Doxygen QUIET)
 
+set(CMAKE_CXX_CPPCHECK cppcheck)
+list(APPEND CMAKE_CXX_CPPCHECK
+  "-i;_deps"
+  "--error-exitcode=2" # 1 is returned on usage error
+  "--enable=warning"
+  "--inconclusive"
+  "--inline-suppr"
+)
+
 add_subdirectory(DOMN)
 add_subdirectory(LOGR)
 add_subdirectory(CTRL)

--- a/CTRL/test/UT_Controller.cpp
+++ b/CTRL/test/UT_Controller.cpp
@@ -25,7 +25,7 @@ public:
 
 TEST(TestController, ExecuteMoveTogglesLogging)
 {
-    auto logr = LOGR::ILoggerStub::create("CTRL_UT");
+    auto logr = LOGR::ILogger::create("CTRL_UT", LOGR::StubSelection::STUB);
     auto driverMock = std::make_shared<NiceMock<DriverMock>>();
 
     Controller controller(driverMock);

--- a/LOGR/include/LOGR/ILogger.hpp
+++ b/LOGR/include/LOGR/ILogger.hpp
@@ -19,19 +19,35 @@ class LoggerAlreadySet : public std::runtime_error
     using std::runtime_error::runtime_error;
 };
 
+enum class StubSelection
+{
+    STUB
+};
+
 ///
 /// \brief Manage a log-file per 'task' / process.
-///
-/// You are expected to `create()` a single `Logger` object in your `main()`
-/// function, which enables the use of the other logging classes for this
-/// object's lifetime. The log-file is closed upon destruction.
-///
-/// All logging is asynchronous and safe to use from multiple threads.
 ///
 class ILogger
 {
 public:
+    ///
+    /// You are expected to `create()` a single `Logger` object in your `main()`
+    /// function, which enables the use of the other logging classes for this
+    /// object's lifetime. The log-file is closed upon destruction.
+    ///
+    /// All logging is asynchronous and safe to use from multiple threads.
+    ///
     static std::shared_ptr<ILogger> create(const std::string& taskName);
+
+    ///
+    /// \brief Creates a stub that logs to stderr (e.g. for unit-tests).
+    ///
+    /// Use this `create()` instead of the production one to enable your system
+    /// under test to use the other logging classes.
+    ///
+    /// All logging calls are thread-safe, but blocking unlike in production.
+    ///
+    static std::shared_ptr<ILogger> create(const std::string& taskName, StubSelection stub);
     virtual ~ILogger() = default;
 
 protected:
@@ -45,20 +61,6 @@ protected:
     virtual void queueLogLine(const std::string& line) = 0;
 
     static std::weak_ptr<ILogger> m_instance;
-};
-
-///
-/// \brief Stub for unit-tests, logs to stderr.
-///
-/// Use this `create()` instead of the production one to enable your system
-/// under test to use the other logging classes.
-///
-/// All logging calls are thread-safe, but blocking unlike in production.
-///
-class ILoggerStub : public ILogger
-{
-public:
-    static std::shared_ptr<ILogger> create(const std::string& taskName);
 };
 
 }

--- a/LOGR/src/ILogger.cpp
+++ b/LOGR/src/ILogger.cpp
@@ -36,7 +36,7 @@ std::shared_ptr<ILogger> ILogger::instance()
 }
 
 
-class LoggerStub : public ILoggerStub
+class LoggerStub : public ILogger
 {
 public:
     LoggerStub(const std::string& taskName)
@@ -55,8 +55,9 @@ private:
     const std::string m_taskName;
 };
 
-std::shared_ptr<ILogger> ILoggerStub::create(const std::string& taskName)
+std::shared_ptr<ILogger> ILogger::create(const std::string& taskName, StubSelection stub)
 {
+    (void) stub;
     auto logger = std::make_shared<LoggerStub>(taskName);
     m_instance = std::dynamic_pointer_cast<ILogger>(logger);
     return std::dynamic_pointer_cast<ILogger>(logger);

--- a/LOGR/test/FT_Logger.cpp
+++ b/LOGR/test/FT_Logger.cpp
@@ -46,7 +46,7 @@ LogLine parse(const std::string& line)
     char message[1024]{};
 
     // 0;1724138058.333385;140379180749760;/linebot/MAIN/src/main.cpp;16;int main();v
-    sscanf(line.c_str(), " %d;%lf;%[^;];%[^;];%li;%[^;];%[^;] ",
+    sscanf(line.c_str(), " %d;%lf;%1023[^;];%1023[^;];%li;%1023[^;];%1023[^;] ",
            &level, &timestamp, threadId, file, &lineNr, function, message);
 
     return LogLine {


### PR DESCRIPTION
A bunch of useful static checks, very fast for the current size of the project, easily integrated with CMake. It's a no-brainer, really.

A failing check will mean a failing build, but suppressions can be added inline in case of false-positives.