### PR TITLE
Add some useful error utilities

### DIFF
--- a/LOGR/include/LOGR/Exception.hpp
+++ b/LOGR/include/LOGR/Exception.hpp
@@ -31,9 +31,11 @@ public:
     void handle(const std::string& message,
         const std::source_location& loc = std::source_location::current()) const;
 
+    long long id() const;
+
 private:
     static std::atomic<unsigned long long> freeId;
-    unsigned long long id{};
+    unsigned long long m_id{};
 };
 
 }

--- a/LOGR/include/LOGR/Exception.hpp
+++ b/LOGR/include/LOGR/Exception.hpp
@@ -38,6 +38,9 @@ private:
     unsigned long long m_id{};
 };
 
+/// Get a string representation of the current value and meaning of errno.
+std::string getUnderlyingError();
+
 }
 
 #endif // LOGR_INCLUDE_LOGR_EXCEPTION

--- a/LOGR/src/Exception.cpp
+++ b/LOGR/src/Exception.cpp
@@ -13,10 +13,10 @@ std::atomic<unsigned long long> LOGR::Exception::freeId = 1;
 
 LOGR::Exception::Exception(const std::string& message,
     const std::source_location& loc)
-    : std::runtime_error(message), id(freeId++)
+    : std::runtime_error(message), m_id(freeId++)
 {
     auto line = internal::startLine(internal::Level::EXCEPTION, loc);
-    line << "> [" << id << "] " << this->what() << "\n";
+    line << "> [" << m_id << "] " << this->what() << "\n";
     LoggerImpl::instance()->queueLogLine(line.str());
 }
 
@@ -24,6 +24,11 @@ void LOGR::Exception::handle(const std::string& message,
     const std::source_location& loc) const
 {
     auto line = internal::startLine(internal::Level::EXCEPTION, loc);
-    line << "< [" << id << "] " << message << "\n";
+    line << "< [" << m_id << "] " << message << "\n";
     LoggerImpl::instance()->queueLogLine(line.str());
+}
+
+long long LOGR::Exception::id() const
+{
+    return m_id;
 }

--- a/LOGR/src/Exception.cpp
+++ b/LOGR/src/Exception.cpp
@@ -5,6 +5,9 @@
 #include <stdexcept>
 #include <string>
 
+#include <cerrno>
+#include <cstring>
+
 #include "LOGR/internal.hpp"
 #include "LoggerImpl.hpp"
 
@@ -32,3 +35,11 @@ long long LOGR::Exception::id() const
 {
     return m_id;
 }
+
+/// Get a string representation of the current value and meaning of errno.
+std::string LOGR::getUnderlyingError()
+{
+    auto e = errno;
+    return std::to_string(e) + ": " + ::strerror(e);
+}
+

--- a/LOGR/test/CMakeLists.txt
+++ b/LOGR/test/CMakeLists.txt
@@ -6,7 +6,7 @@ add_executable(
 )
 target_link_libraries(
     ${PROJECT_NAME}
-    GTest::gtest_main
+    GTest::gmock_main
     LOGR
 )
 

--- a/LOGR/test/FT_Logger.cpp
+++ b/LOGR/test/FT_Logger.cpp
@@ -3,7 +3,8 @@
 #include "LOGR/Trace.hpp"
 #include "LOGR/Warning.hpp"
 
-#include <gtest/gtest.h>
+#include "gtest/gtest.h"
+#include "gmock/gmock-matchers.h"
 
 #include <filesystem>
 #include <fstream>
@@ -17,6 +18,9 @@
 using namespace LOGR;
 using namespace internal;
 using src_loc = std::source_location;
+
+using testing::StartsWith;
+using testing::HasSubstr;
 
 
 namespace
@@ -156,4 +160,17 @@ TEST(TestLoggerFunctional, LogsDifferentLevels)
     EXPECT_EQ(  log.line,      expectedTraceLocation);
     EXPECT_EQ(  log.function,  src_loc::current().function_name());
     EXPECT_EQ(  log.message,   "^");
+}
+
+TEST(TestGetUnderlyingError, ReturnsMessage)
+{
+    std::ifstream nonExistentFile;
+    nonExistentFile.open("justsomenonexistentfileIhopenoonecreatesit.txt");
+
+    ASSERT_FALSE(nonExistentFile.is_open());
+
+    const std::string prefix = std::to_string(ENOENT) + ": ";
+
+    EXPECT_THAT(LOGR::getUnderlyingError(), StartsWith(prefix));
+    EXPECT_THAT(LOGR::getUnderlyingError(), HasSubstr("No such file"));
 }

--- a/LOGR/test/FT_Logger.cpp
+++ b/LOGR/test/FT_Logger.cpp
@@ -61,25 +61,34 @@ LogLine parse(const std::string& line)
 
 } // anonymous namespace
 
-TEST(TestLoggerFunctional, CreatesLogfile)
+class TestLoggerFunctional : public ::testing::Test
 {
-    const time_t creationTime = ::time(nullptr);
+protected:
+    void TearDown() override
+    {
+        std::filesystem::remove(expectedFile);
+    }
 
+    const time_t creationTime = ::time(nullptr);
+    const std::string expectedFile = "LOGR_TEST_"
+                                     + std::to_string(creationTime)
+                                     + ".csv";
+};
+
+TEST_F(TestLoggerFunctional, CreatesLogfile)
+{
     ILogger::create("TEST");
 
-    const std::string expectedFile = "LOGR_TEST_"
-                                     + std::to_string(creationTime) + ".csv";
     ASSERT_TRUE(std::filesystem::exists(expectedFile));
 }
 
-TEST(TestLoggerFunctional, LogsDifferentLevels)
+TEST_F(TestLoggerFunctional, LogsDifferentLevels)
 {
     long expectedTraceLocation{};
     long expectedWarnLocation{};
     long expectedExcLocation{};
     long expectedHandleLocation{};
 
-    const time_t creationTime = ::time(nullptr);
     {
         auto logger = ILogger::create("TEST");
 
@@ -96,8 +105,6 @@ TEST(TestLoggerFunctional, LogsDifferentLevels)
         expectedHandleLocation = src_loc::current().line() - 1;
     }
 
-    const std::string expectedFile = "LOGR_TEST_"
-                                     + std::to_string(creationTime) + ".csv";
     std::ifstream file(expectedFile);
 
     std::ostringstream threadId;


### PR DESCRIPTION
1. A client that creates or catches an exception may want to refer to its ID, so this PR makes it available via `LOGR::Exception::id()`.
2. When logging an error that arises from a standard library failure, it is useful to have the error code and text from the library/system. Hence `LOGR::getUnderlyingError()` is provided.
3. The `FT_Logger` functional test produces log files at each execution. This PR makes a reasonable effort to clean those up. They will remain if they don't match the expected name, which may not necessarily be a downside.
