### PR TITLE
UI: Fix getting DRVR position many times per frame

### DIFF
--- a/UI/src/UserInterface.cpp
+++ b/UI/src/UserInterface.cpp
@@ -24,10 +24,12 @@ static void draw(std::weak_ptr<DRVR::IDriverClient> driver, std::ostream& output
     std::shared_ptr<DRVR::IDriverClient> dr = driver.lock();
     if (dr)
     {
+        const double position = dr->position();
+
         output << '\r' << '|';
         for (size_t i = 0; i < WIDTH; i++)
         {
-            if (std::round(dr->position() * WIDTH) == i)
+            if (std::round(position * WIDTH) == i)
             {
                 output << '+';
             }


### PR DESCRIPTION
IDriver::position() looks like (and used to be) a simple getter, but now it's an inter-process call. At the moment, that's made even more expensive by the IPC mutex, which CTRL and UI compete for in the same MAIN process.