### PR TITLE
COMM: Add a top-level target for building all 'interfaces'

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -43,6 +43,8 @@ include_directories(${CMAKE_CURRENT_BINARY_DIR})
 
 find_package(Doxygen QUIET)
 
+add_custom_target(interfaces)
+
 add_subdirectory(COMM)
 add_subdirectory(DOMN)
 add_subdirectory(LOGR)

--- a/COMM/CMakeLists.txt
+++ b/COMM/CMakeLists.txt
@@ -72,6 +72,8 @@ function(add_interface component interface)
     )
 
     target_link_libraries(${interface}_interface PUBLIC COMM)
+
+    add_dependencies(interfaces ${interface}_interface)
 endfunction()
 
 add_subdirectory(test)


### PR DESCRIPTION
All COMM interfaces created using `add_interface()` can now be generated & built using `make interfaces`.

Helpful when:
- adding/changing interfaces, to generate the headers before implementing them;
- checking out a branch/commit for browsing, to generate the headers for navigation;
- making changes to the `interface_generator` itself.