### PR TITLE
Override PR number in comment workflow

### DIFF
--- a/.github/workflows/comment-on-pull-request.yml
+++ b/.github/workflows/comment-on-pull-request.yml
@@ -41,3 +41,4 @@ jobs:
           message-path: known-fail-passed-*-comment.txt
           refresh-message-position: true
           allow-repeats: true
+          issue: ${{ github.event.workflow_run.pull_requests[0].number }}


### PR DESCRIPTION
The comment was somehow ending up on the wrong pull request (called an 'issue' in the action API because they share one numbering sequence).