### PR TITLE
Tidy up test CMakeLists

### DIFF
--- a/COMM/test/CMakeLists.txt
+++ b/COMM/test/CMakeLists.txt
@@ -7,7 +7,7 @@ add_executable(
 )
 target_link_libraries(FT_Connection_SUT PRIVATE COMM)
 add_test(
-    NAME COMM::FT_ConnectionTest
+    NAME COMM::FT_Connection
     COMMAND
         ${CMAKE_COMMAND} -E env "PYTHONPATH=${CMAKE_CURRENT_SOURCE_DIR}"
         ${Python_EXECUTABLE}
@@ -22,7 +22,7 @@ add_executable(
 )
 target_link_libraries(FT_Socket_SUT PRIVATE COMM)
 add_test(
-    NAME COMM::FT_SocketTest
+    NAME COMM::FT_Socket
     COMMAND
         ${CMAKE_COMMAND} -E env "PYTHONPATH=${CMAKE_CURRENT_SOURCE_DIR}"
         ${Python_EXECUTABLE}
@@ -37,7 +37,7 @@ add_executable(
 )
 target_link_libraries(FT_Watcher_SUT PRIVATE COMM)
 add_test(
-    NAME COMM::FT_WatcherTest
+    NAME COMM::FT_Watcher
     COMMAND
         ${CMAKE_COMMAND} -E env "PYTHONPATH=${CMAKE_CURRENT_SOURCE_DIR}"
         ${Python_EXECUTABLE}
@@ -52,7 +52,7 @@ add_executable(
 )
 target_link_libraries(FT_Server_SUT PRIVATE COMM)
 add_test(
-    NAME COMM::FT_ServerTest
+    NAME COMM::FT_Server
     COMMAND
         ${CMAKE_COMMAND} -E env "PYTHONPATH=${CMAKE_CURRENT_SOURCE_DIR}"
         ${Python_EXECUTABLE}
@@ -99,7 +99,7 @@ target_link_libraries(
 )
 
 add_test(
-    NAME COMM::FT_interface_generator_test
+    NAME COMM::FT_interface_generator
     COMMAND
         ${CMAKE_COMMAND} -E env "PYTHONPATH=${CMAKE_CURRENT_SOURCE_DIR}"
         ${Python_EXECUTABLE}

--- a/COMM/test/CMakeLists.txt
+++ b/COMM/test/CMakeLists.txt
@@ -107,16 +107,3 @@ add_test(
         ${CMAKE_CURRENT_BINARY_DIR}/FT_interface_generator_server_SUT
         ${CMAKE_CURRENT_BINARY_DIR}/FT_interface_generator_client_SUT
 )
-
-# add_executable(
-#     TODO_test
-#     test_reader.cpp
-# )
-# target_link_libraries(
-#     TODO_test
-#     GTest::gtest_main
-#     ${PROJECT_NAME}_lib
-# )
-
-include(GoogleTest)
-# gtest_discover_tests(TODO_test)

--- a/CTRL/test/CMakeLists.txt
+++ b/CTRL/test/CMakeLists.txt
@@ -1,14 +1,13 @@
 project(CTRL_test)
 
 add_executable(
-    ${PROJECT_NAME}
+    UT_Controller
     UT_Controller.cpp
 )
 target_link_libraries(
-    ${PROJECT_NAME}
+    UT_Controller
     GTest::gmock_main
     CTRL
 )
 
-include(GoogleTest)
-gtest_discover_tests(${PROJECT_NAME})
+add_test(NAME CTRL::UT_Controller COMMAND UT_Controller)

--- a/DOMN/test/CMakeLists.txt
+++ b/DOMN/test/CMakeLists.txt
@@ -1,14 +1,1 @@
-project(TODO_test)
-
-# add_executable(
-#     TODO_test
-#     test_reader.cpp
-# )
-# target_link_libraries(
-#     TODO_test
-#     GTest::gtest_main
-#     ${PROJECT_NAME}_lib
-# )
-
-include(GoogleTest)
-# gtest_discover_tests(TODO_test)
+project(DOMN_test)

--- a/DRVR/test/CMakeLists.txt
+++ b/DRVR/test/CMakeLists.txt
@@ -13,5 +13,4 @@ target_link_libraries(
 )
 enable_target_warnings(FT_Driver)
 
-include(GoogleTest)
-gtest_discover_tests(FT_Driver)
+add_test(NAME DRVR::FT_Driver COMMAND FT_Driver)

--- a/LOGR/test/CMakeLists.txt
+++ b/LOGR/test/CMakeLists.txt
@@ -1,14 +1,13 @@
 project(LOGR_test)
 
 add_executable(
-    ${PROJECT_NAME}
+    FT_Logger
     FT_Logger.cpp
 )
 target_link_libraries(
-    ${PROJECT_NAME}
+    FT_Logger
     GTest::gmock_main
     LOGR
 )
 
-include(GoogleTest)
-gtest_discover_tests(LOGR_test)
+add_test(NAME LOGR::FT_Logger COMMAND FT_Logger)

--- a/MAIN/test/CMakeLists.txt
+++ b/MAIN/test/CMakeLists.txt
@@ -1,14 +1,1 @@
-project(TODO_test)
-
-# add_executable(
-#     TODO_test
-#     test_reader.cpp
-# )
-# target_link_libraries(
-#     TODO_test
-#     GTest::gtest_main
-#     ${PROJECT_NAME}_lib
-# )
-
-include(GoogleTest)
-# gtest_discover_tests(TODO_test)
+project(MAIN_test)

--- a/UI/test/CMakeLists.txt
+++ b/UI/test/CMakeLists.txt
@@ -1,11 +1,11 @@
 project(UI_test)
 
 add_executable(
-    UI_test
+    UT_MoveInput
     UT_MoveInput.cpp
 )
 target_link_libraries(
-    UI_test
+    UT_MoveInput
     GTest::gmock_main
     UI
     Driver_interface
@@ -13,5 +13,4 @@ target_link_libraries(
     LOGR
 )
 
-include(GoogleTest)
-gtest_discover_tests(UI_test)
+add_test(NAME UI::UT_MoveInput COMMAND UT_MoveInput)


### PR DESCRIPTION
1. There were some leftover comments.
2. The number of 'individual' tests blows up with `gtest_discover_tests`, so I've decided against using it.
   It also caused each test case to be executed separately, which I find unnecessary (hopefully at some point the speedup from running the suites together will matter, for now it's half a second's difference).
3. Some COMM tests were suffixed 'Test'/'_test', which is redundant (the FT/UT prefix has T for Test).