### PR TITLE
Add a Tick class for sleeping regularly

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -45,6 +45,7 @@ find_package(Doxygen QUIET)
 
 add_custom_target(interfaces)
 
+add_subdirectory(SYNC)
 add_subdirectory(COMM)
 add_subdirectory(DOMN)
 add_subdirectory(LOGR)

--- a/DRVR/CMakeLists.txt
+++ b/DRVR/CMakeLists.txt
@@ -22,6 +22,6 @@ add_executable(
 )
 enable_target_warnings(DRVR_main)
 
-target_link_libraries(DRVR_main Threads::Threads Driver_interface DOMN LOGR)
+target_link_libraries(DRVR_main PRIVATE Threads::Threads Driver_interface DOMN SYNC LOGR)
 
 add_subdirectory(test)

--- a/DRVR/src/Driver.cpp
+++ b/DRVR/src/Driver.cpp
@@ -3,6 +3,7 @@
 #include "DOMN/Move.hpp"
 #include "LOGR/Trace.hpp"
 #include "LOGR/Warning.hpp"
+#include "SYNC/Tick.hpp"
 
 #include <algorithm>
 #include <iostream>
@@ -69,14 +70,11 @@ void Driver::simulate(int refreshRate_ms)
 
     LOGR::Trace trace;
 
-    auto currentTime = system_clock::now();
-    auto previousTime = currentTime;
+    SYNC::StrictTick tick{milliseconds(refreshRate_ms)};
 
     while (m_running)
     {
-        currentTime = system_clock::now();
-
-        const auto deltaTime_ms = duration_cast<milliseconds>(currentTime - previousTime);
+        const auto deltaTime_ms = duration_cast<milliseconds>(tick.deltaTime());
         const double deltaTime_s = deltaTime_ms.count() / 1000.0;
 
         m_velocity += m_acceleration * deltaTime_s;
@@ -95,8 +93,7 @@ void Driver::simulate(int refreshRate_ms)
             m_logFile << m_position << '\t';
         }
 
-        previousTime = currentTime;
-        std::this_thread::sleep_for(milliseconds(refreshRate_ms));
+        tick();
     }
 }
 

--- a/DRVR/test/CMakeLists.txt
+++ b/DRVR/test/CMakeLists.txt
@@ -9,6 +9,7 @@ target_link_libraries(
     FT_Driver
     Driver_interface
     DOMN
+    SYNC
     GTest::gtest_main
 )
 enable_target_warnings(FT_Driver)

--- a/DRVR/test/FT_Driver.cpp
+++ b/DRVR/test/FT_Driver.cpp
@@ -50,9 +50,9 @@ TEST_F(TestDriverFunctional, Moves)
 {
     constexpr double inputVelocity = 0.2;
 
-    driver.setVelocity(inputVelocity);
-
     EXPECT_NEAR(driver.position(), STARTING_POSITION, .00001);
+
+    driver.setVelocity(inputVelocity);
     EXPECT_NEAR(driver.velocity(), inputVelocity, .00001);
 
     constexpr int sleepTicks = 10;
@@ -69,9 +69,9 @@ TEST_F(TestDriverFunctional, Accelerates)
 {
     constexpr double inputAcceleration = 0.2;
 
-    driver.setAcceleration(inputAcceleration);
-
     EXPECT_NEAR(driver.velocity(), 0.0, .00001);
+
+    driver.setAcceleration(inputAcceleration);
 
     constexpr int sleepTicks = 10;
     constexpr std::chrono::milliseconds sleepTime{REFRESH_RATE_MS * sleepTicks};

--- a/SYNC/CMakeLists.txt
+++ b/SYNC/CMakeLists.txt
@@ -1,0 +1,24 @@
+project(SYNC)
+
+set(SRC_PATH ${CMAKE_CURRENT_SOURCE_DIR}/src)
+set(EXT_INC_PATH ${CMAKE_CURRENT_SOURCE_DIR}/include)
+set(INT_INC_PATH ${CMAKE_CURRENT_SOURCE_DIR}/inc)
+
+include_directories(${INT_INC_PATH})
+include_directories(${EXT_INC_PATH})
+
+# if(Doxygen_FOUND)
+#     doxygen_add_docs(SYNC_docs)
+# endif()
+
+add_library(
+    ${PROJECT_NAME} SHARED
+    ${EXT_INC_PATH}/${PROJECT_NAME}/Tick.hpp
+
+    ${SRC_PATH}/Tick.cpp
+)
+enable_target_warnings(${PROJECT_NAME})
+
+target_include_directories(${PROJECT_NAME} PUBLIC ${EXT_INC_PATH})
+
+add_subdirectory(test)

--- a/SYNC/CMakeLists.txt
+++ b/SYNC/CMakeLists.txt
@@ -21,4 +21,6 @@ enable_target_warnings(${PROJECT_NAME})
 
 target_include_directories(${PROJECT_NAME} PUBLIC ${EXT_INC_PATH})
 
+target_link_libraries(${PROJECT_NAME} LOGR)
+
 add_subdirectory(test)

--- a/SYNC/include/SYNC/Tick.hpp
+++ b/SYNC/include/SYNC/Tick.hpp
@@ -1,0 +1,30 @@
+#ifndef SYNC_INCLUDE_SYNC_TICK
+#define SYNC_INCLUDE_SYNC_TICK
+
+#include <chrono>
+
+namespace SYNC
+{
+
+class Tick
+{
+public:
+    static constexpr auto MAX_DRIFT = std::chrono::microseconds(500);
+
+    using clock = std::chrono::steady_clock;
+
+    Tick(clock::duration refreshRate);
+
+    void operator()();
+
+    inline clock::duration deltaTime() { return std::max(m_deltaTime, m_refreshRate); }
+
+private:
+    const clock::duration m_refreshRate;
+    clock::time_point m_endOfLastTick;
+    clock::duration m_deltaTime;
+};
+
+} // SYNC
+
+#endif // SYNC_INCLUDE_SYNC_TICK

--- a/SYNC/include/SYNC/Tick.hpp
+++ b/SYNC/include/SYNC/Tick.hpp
@@ -2,6 +2,7 @@
 #define SYNC_INCLUDE_SYNC_TICK
 
 #include <chrono>
+#include <source_location>
 
 namespace SYNC
 {
@@ -19,10 +20,18 @@ public:
 
     inline clock::duration deltaTime() { return std::max(m_deltaTime, m_refreshRate); }
 
-private:
+protected:
     const clock::duration m_refreshRate;
     clock::time_point m_endOfLastTick;
     clock::duration m_deltaTime;
+};
+
+class StrictTick : public Tick
+{
+public:
+    using Tick::Tick;
+
+    void operator()(const std::source_location& loc = std::source_location::current());
 };
 
 } // SYNC

--- a/SYNC/src/Tick.cpp
+++ b/SYNC/src/Tick.cpp
@@ -1,5 +1,7 @@
 #include "SYNC/Tick.hpp"
 
+#include "LOGR/Warning.hpp"
+
 #include <thread>
 
 using namespace SYNC;
@@ -25,4 +27,15 @@ void Tick::operator()()
 
     m_deltaTime = endOfTick - m_endOfLastTick;
     m_endOfLastTick = endOfTick;
+}
+
+void StrictTick::operator()(const std::source_location& loc)
+{
+    Tick::operator()();
+
+    if (m_deltaTime > (m_refreshRate + MAX_DRIFT))
+    {
+        LOGR::Warning<const char*, const clock::duration&, const char*, const clock::duration&>
+        {"Overran", m_refreshRate, "with delta time", m_deltaTime, loc};
+    }
 }

--- a/SYNC/src/Tick.cpp
+++ b/SYNC/src/Tick.cpp
@@ -1,0 +1,28 @@
+#include "SYNC/Tick.hpp"
+
+#include <thread>
+
+using namespace SYNC;
+using namespace std::chrono;
+
+Tick::Tick(clock::duration refreshRate)
+    : m_refreshRate(refreshRate),
+    m_endOfLastTick(clock::now()),
+    m_deltaTime()
+{
+}
+
+void Tick::operator()()
+{
+
+    const time_point start = clock::now();
+    const duration elapsed = start - m_endOfLastTick;
+
+    const time_point target = start + (m_refreshRate - elapsed);
+    std::this_thread::sleep_until(target);
+
+    const time_point endOfTick = clock::now();
+
+    m_deltaTime = endOfTick - m_endOfLastTick;
+    m_endOfLastTick = endOfTick;
+}

--- a/SYNC/test/CMakeLists.txt
+++ b/SYNC/test/CMakeLists.txt
@@ -1,0 +1,11 @@
+project(SYNC_test)
+
+add_executable(
+    FT_Tick
+    FT_Tick.cpp
+    ${SRC_PATH}/Tick.cpp
+)
+target_link_libraries(FT_Tick GTest::gtest_main LOGR pthread)
+enable_target_warnings(FT_Tick)
+
+add_test(NAME SYNC::FT_Tick COMMAND FT_Tick)

--- a/SYNC/test/FT_Tick.cpp
+++ b/SYNC/test/FT_Tick.cpp
@@ -1,0 +1,64 @@
+#include "SYNC/Tick.hpp"
+
+#include <gtest/gtest.h>
+
+#include <chrono>
+#include <numeric>
+
+using namespace std::chrono;
+using namespace SYNC;
+
+class TestTick : public testing::Test
+{
+public:
+    static constexpr size_t NR_TICKS = 50;
+    static constexpr auto TICK_TIME = 8ms;
+
+    Tick tick{TICK_TIME};
+};
+
+TEST_F(TestTick, takesExactTime)
+{
+    constexpr auto UPPER_LIMIT = Tick::MAX_DRIFT * NR_TICKS;
+
+    // When
+    auto start = steady_clock::now();
+    for (size_t i = 0; i < NR_TICKS; i++)
+    {
+        tick();
+    }
+    auto end = steady_clock::now();
+
+    // Then
+    auto total = duration_cast<milliseconds>(end - start);
+
+    EXPECT_GT(total, (NR_TICKS * TICK_TIME));
+    EXPECT_LT(total, (NR_TICKS * TICK_TIME) + UPPER_LIMIT);
+}
+
+TEST_F(TestTick, reportsAccurateDeltaTime)
+{
+    constexpr auto MAX_DEVIATION_MS = NR_TICKS * TICK_TIME * 0.05;
+
+    // Given
+    std::vector<Tick::clock::duration> reportedDeltas;
+    reportedDeltas.reserve(NR_TICKS);
+
+    // When
+    auto start = steady_clock::now();
+    for (size_t i = 0; i < NR_TICKS; i++)
+    {
+        tick();
+        reportedDeltas.push_back(tick.deltaTime());
+    }
+    auto end = steady_clock::now();
+
+    // Then
+    auto total = duration_cast<milliseconds>(end - start);
+    auto reportedSum = duration_cast<milliseconds>(
+        std::accumulate(reportedDeltas.begin(), reportedDeltas.end(), 0ns)
+    );
+
+    EXPECT_NEAR(reportedSum.count(), total.count(), MAX_DEVIATION_MS.count());
+}
+

--- a/UI/CMakeLists.txt
+++ b/UI/CMakeLists.txt
@@ -21,6 +21,6 @@ target_include_directories(
     ${PROJECT_NAME} PUBLIC ${EXT_INC_PATH}
 )
 
-target_link_libraries(${PROJECT_NAME} PRIVATE Threads::Threads DOMN LOGR Driver_interface)
+target_link_libraries(${PROJECT_NAME} PRIVATE Threads::Threads SYNC DOMN LOGR Driver_interface)
 
 add_subdirectory(test)

--- a/UI/src/UserInterface.cpp
+++ b/UI/src/UserInterface.cpp
@@ -4,6 +4,7 @@
 
 #include "DOMN/Move.hpp"
 #include "LOGR/Trace.hpp"
+#include "SYNC/Tick.hpp"
 
 #include <cmath>
 #include <iostream>
@@ -59,6 +60,8 @@ void UserInterface::run(
         m_running = true;
         m_running.notify_one();
 
+        SYNC::Tick tick{refreshRate};
+
         while (m_running && not driver.expired())
         {
             if (m_outputMutex.try_lock())
@@ -67,7 +70,7 @@ void UserInterface::run(
                 draw(driver, std::cout);
             }
 
-            std::this_thread::sleep_for(refreshRate);
+            tick();
         }
 
         m_running = false;


### PR DESCRIPTION
We already had some flawed code for this, not-quite-duplicated across DRVR and UI.
Now we have a more robust abstraction that's simple to use.

As usual, I suggest following the commits when reviewing.

## Usage
You create a `SYNC::Tick` object with some time interval.
When you call that object, it checks how long it has been since the last call (called `deltaTime`), and sleeps for the rest of the specified interval.
You can also check the `deltaTime` (e.g. DRVR needs this for time-dependent calculations).

There is a `SYNC::StrictTick` variant which logs a warning in case two calls to it are longer apart than the expected time interval. That's not _particularly_ strict, we can add more variants as the need arises.

## Future
There should definitely be a real-time variant that doesn't allow overshoots at all; the ones here call `sleep_for()` which basically always takes slightly longer than requested, as is reflected in the tests.
We don't _yet_ have a pressing need for that, and we'll need OS-specific calls, etc. so now is not the time.

Another one we should have is a mock Tick that lets us decouple tests from physical time.
It would also be great to be able to hot-swap this into real execution, so that we can pause multiple processes for debugging and 'single-step' them without messing up their calculations.